### PR TITLE
Fix wrong matrix size

### DIFF
--- a/Utils/computeKinematics.m
+++ b/Utils/computeKinematics.m
@@ -31,7 +31,7 @@ for i = 1:smds.NB
     X{i}{1,i} = eye(6);
     XForce{i}{1,i} = eye(6);
     for j = i+1:smds.NB
-        X{i}{1,j} = eye(smds.NB);
+        X{i}{1,j} = eye(6);
         for k = i+1:j
             X{i}{1,j} = Xup{k}*X{i}{1,j};
         end


### PR DESCRIPTION
As @VModugno noticed in https://github.com/robotology/urdf2casadi-matlab/issues/14#issue-902932722 the spatial transformation matrix should be 6x6.