### PR TITLE
Add small threshold for non perfect null axis vector components

### DIFF
--- a/+urdf2casadi/+Utils/+modelExtractionFunctions/setJointType.m
+++ b/+urdf2casadi/+Utils/+modelExtractionFunctions/setJointType.m
@@ -5,6 +5,7 @@ function [type,axis] = setJointType(model, jointIndex)
 % Set default value for the type and axis
 type = '';
 axis = [0 0 0];
+zeroTol = 1e-5;
 if (strcmp(model.robot.joint{1,jointIndex}.Attributes.type,'fixed'))   
     if  isfield(model.robot.joint{1,jointIndex}, 'axis')
         axis = str2num(model.robot.joint{1,jointIndex}.axis.Attributes.xyz);
@@ -23,13 +24,15 @@ if (strcmp(model.robot.joint{1,jointIndex}.Attributes.type,'continuous') || strc
         % Default axis value according to http://wiki.ros.org/urdf/XML/joint
         axis = [1 0 0];
     end
-    if ((axis(1)~=0) && (axis(2)==0) && (axis(3)==0))
+    % Check the axis vector components. Take into account possible numerical errors in the URDFs with non
+    % perfectly null `axis` vector components using a small threshold.
+    if (abs(axis(1))>= 1-zeroTol && abs(axis(2))<=zeroTol && abs(axis(3))<=zeroTol)
         type = 'Rx';
     end
-    if ((axis(1)==0) && (axis(2)~=0) && (axis(3)==0))
+    if (abs(axis(1))<=zeroTol && abs(axis(2))>= 1-zeroTol && abs(axis(3))<=zeroTol)
         type = 'Ry';
     end
-    if ((axis(1)==0) && (axis(2)==0) && (axis(3)~=0))
+    if (abs(axis(1))<=zeroTol && abs(axis(2))<=zeroTol && abs(axis(3))>= 1-zeroTol)
         type = 'Rz';
     end
 end
@@ -41,13 +44,15 @@ if (strcmp(model.robot.joint{1,jointIndex}.Attributes.type,'prismatic'))
         % Default axis value according to http://wiki.ros.org/urdf/XML/joint
         axis = [1 0 0];
     end
-    if ((axis(1)~=0) && (axis(2)==0) && (axis(3)==0))
+    % Check the axis vector components. Take into account possible numerical errors in the URDFs with non
+    % perfectly null `axis` vector components using a small threshold.
+    if (abs(axis(1))>= 1-zeroTol && abs(axis(2))<=zeroTol && abs(axis(3))<=zeroTol)
         type = 'Px';
     end
-    if ((axis(1)==0) && (axis(2)~=0) && (axis(3)==0))
+    if (abs(axis(1))<=zeroTol && abs(axis(2))>= 1-zeroTol && abs(axis(3))<=zeroTol)
         type = 'Py';
     end
-    if ((axis(1)==0) && (axis(2)==0) && (axis(3)~=0))
+    if (abs(axis(1))<=zeroTol && abs(axis(2))<=zeroTol && abs(axis(3))>= 1-zeroTol)
         type = 'Pz';
     end
 end

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Its documentation can be found at https://robotology.github.io/idyntree/master/.
 Make sure to compile the [bindings to MATLAB](https://github.com/robotology/idyntree#bindings).
 Some usefull turorial can be found at https://github.com/robotology/idyntree#tutorials .
 
+## URDF specifications
+The URDF specifications and its mathematical description that has been used in this repository can be found [here](https://github.com/robotology/blender-robotics-utils/issues/3#issuecomment-906262419). Only joints with the [`axis`](http://wiki.ros.org/urdf/XML/joint) aligned with one of the three directions of the joint frame are supported.
+
 ## Usage 
 Add to the [MATLAB path](https://mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html) the repository and all its subfolders by launching `setPath.m`, make sure to insert the correct path to CasADi.Get the [URDF](http://wiki.ros.org/urdf) of your robot. Then pick one of the functions to create and test the model against IDynTree 
 in the Verification/ subfolder. Each test* script should be launched from the folder it is contained in.


### PR DESCRIPTION
In some URDF files have the [`axis` attribute](http://wiki.ros.org/urdf/XML/joint) of the joints, i.e. the joint axis specified in the joint frame, have non perfectly null components for simple revolute or prismatic joints. See for example https://github.com/robotology/urdf2casadi-matlab/blob/a1fa3a9398f582448cd7ae9b083d29ff7313c73e/URDFs/iCubGenova9.urdf#L439 To set appropriately the joint type it is better to use a numerical threshold.
For a mathematical description of the URDF formalism see https://github.com/robotology/blender-robotics-utils/issues/3#issuecomment-906262419.